### PR TITLE
Disable stdout buffering

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,7 @@ int main(int argc, char **argv)
                 return -1;
         }
 
+    setbuf(stdout, NULL);
     if(!foreground)
         daemon(0,0);
 


### PR DESCRIPTION
I am disabling stderr buffering in order to use this server in a OSX wrapper that I'm planning to use in tandem with a Wine encapsuled HDSDR.
